### PR TITLE
Upgrade MLflow in test_regression_model

### DIFF
--- a/components/test_regression_model/conda.yml
+++ b/components/test_regression_model/conda.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - pandas=1.1.4
   - pip=20.3.3
-  - mlflow=1.14.1
+  - mlflow=1.17.0
   - scikit-learn=0.24.1
   - pip:
       - wandb==0.10.31


### PR DESCRIPTION
* Upgrade mlflow to 1.17.0

This commit also fixes the problem with this step crashing with error:
`OSError: No such file or directory: './artifacts/random_forest_export%3Av19'`